### PR TITLE
fix: labs day 3

### DIFF
--- a/src/2.04 - Service Accounts/Exercise/README.md
+++ b/src/2.04 - Service Accounts/Exercise/README.md
@@ -26,7 +26,10 @@ All tasks must be completed as **declaratively as possible**—use manifests, no
 
 1.  Create the ServiceAccount Manifest
 
-Create a YAML manifest file named `sa-squadron.yaml` with the following content
+Create a YAML manifest file for the ServiceAccount `sa-squadron.yaml` with the following specification:
+
+* namespace: default
+* name: sa-squadron
 
 ---
 

--- a/src/3.07 - Troubleshooting/3.07.3 - Echoes in the Void - The Volume That Never Mounted/Solution/deployment.yaml
+++ b/src/3.07 - Troubleshooting/3.07.3 - Echoes in the Void - The Volume That Never Mounted/Solution/deployment.yaml
@@ -27,4 +27,4 @@ spec:
       volumes:
       - name: database-storage
         persistentVolumeClaim:
-          claimName: db-pvc
+          claimName: database-pvc

--- a/src/3.07 - Troubleshooting/3.07.3 - Echoes in the Void - The Volume That Never Mounted/Solution/pvc.yaml
+++ b/src/3.07 - Troubleshooting/3.07.3 - Echoes in the Void - The Volume That Never Mounted/Solution/pvc.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: db-pvc
+  name: database-pvc
 spec:
   accessModes:
     - ReadWriteMany
   resources:
     requests:
       storage: 10Gi
-  storageClassName: premium-ssd
+  storageClassName: azurefile-csi-premium

--- a/src/3.07 - Troubleshooting/3.07.4 -  Silent Credentials - The Forbidden Secret/Exercise/deployment.yaml
+++ b/src/3.07 - Troubleshooting/3.07.4 -  Silent Credentials - The Forbidden Secret/Exercise/deployment.yaml
@@ -14,29 +14,17 @@ spec:
       labels:
         app: secure-app
     spec:
-      serviceAccountName: app-service-account
+      serviceAccountName: app-account
       containers:
       - name: app
-        image: busybox:1.35
+        image: curlimages/curl:8.5.0
         command: ['sh', '-c']
         args:
         - |
-          echo "Trying to access secret..."
-          cat /var/secrets/username
-          cat /var/secrets/password
-          echo "Secret access successful!"
+          echo "Requesting secret via Kubernetes API..."
+          TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          curl -s -H "Authorization: Bearer $TOKEN" \
+               --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+               https://kubernetes.default.svc/api/v1/namespaces/secure-app/secrets/app-credentials
+          echo "Finished API request."
           sleep 3600
-        volumeMounts:
-        - name: secret-volume
-          mountPath: /var/secrets
-          readOnly: true
-        env:
-        - name: API_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: application-secrets
-              key: api-token
-      volumes:
-      - name: secret-volume
-        secret:
-          secretName: app-credentials

--- a/src/3.07 - Troubleshooting/3.07.4 -  Silent Credentials - The Forbidden Secret/Exercise/service-account.yaml
+++ b/src/3.07 - Troubleshooting/3.07.4 -  Silent Credentials - The Forbidden Secret/Exercise/service-account.yaml
@@ -27,7 +27,7 @@ metadata:
   namespace: secure-app
 subjects:
 - kind: ServiceAccount
-  name: application-sa
+  name: service-account
   namespace: secure-app
 roleRef:
   kind: Role

--- a/src/3.07 - Troubleshooting/3.07.4 -  Silent Credentials - The Forbidden Secret/Solution/deployment.yaml
+++ b/src/3.07 - Troubleshooting/3.07.4 -  Silent Credentials - The Forbidden Secret/Solution/deployment.yaml
@@ -17,26 +17,14 @@ spec:
       serviceAccountName: app-service-account
       containers:
       - name: app
-        image: busybox:1.35
+        image: curlimages/curl:8.5.0
         command: ['sh', '-c']
         args:
         - |
-          echo "Trying to access secret..."
-          cat /var/secrets/username
-          cat /var/secrets/password
-          echo "Secret access successful!"
+          echo "Requesting secret via Kubernetes API..."
+          TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          curl -s -H "Authorization: Bearer $TOKEN" \
+               --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+               https://kubernetes.default.svc/api/v1/namespaces/secure-app/secrets/app-credentials
+          echo "Finished API request."
           sleep 3600
-        volumeMounts:
-        - name: secret-volume
-          mountPath: /var/secrets
-          readOnly: true
-        env:
-        - name: API_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: application-secrets
-              key: api-token
-      volumes:
-      - name: secret-volume
-        secret:
-          secretName: app-credentials

--- a/src/3.07 - Troubleshooting/3.07.4 -  Silent Credentials - The Forbidden Secret/Solution/service-account.yaml
+++ b/src/3.07 - Troubleshooting/3.07.4 -  Silent Credentials - The Forbidden Secret/Solution/service-account.yaml
@@ -18,6 +18,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,7 +30,7 @@ metadata:
   namespace: secure-app
 subjects:
 - kind: ServiceAccount
-  name: application-sa
+  name: app-service-account
   namespace: secure-app
 roleRef:
   kind: Role

--- a/src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Exercise/configmap.yaml
+++ b/src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Exercise/configmap.yaml
@@ -6,13 +6,14 @@ metadata:
 data:
   init.sql: |
     CREATE DATABASE IF NOT EXISTS appdb;
+    DROP USER IF EXISTS 'appuser'@'%';
     CREATE USER 'appuser'@'%' IDENTIFIED BY 'password';
     GRANT ALL PRIVILEGES ON appdb.* TO 'appuser'@'%';
     FLUSH PRIVILEGES;
   setup.sh: |
     #!/bin/bash
     echo "Initializing database..."
-    mysql -h mysql-service -u root -p$MYSQL_ROOT_PASSWORD < /scripts/init.sql
+    mysql -h mysql -u root -p$MYSQL_ROOT_PASSWORD < /scripts/init.sql
     if [ $? -eq 0 ]; then
       echo "Database initialized successfully"
       touch /shared/db-ready

--- a/src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Solution/configmap.yaml
+++ b/src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Solution/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   init.sql: |
     CREATE DATABASE IF NOT EXISTS appdb;
+    DROP USER IF EXISTS 'appuser'@'%';
     CREATE USER 'appuser'@'%' IDENTIFIED BY 'password';
     GRANT ALL PRIVILEGES ON appdb.* TO 'appuser'@'%';
     FLUSH PRIVILEGES;

--- a/src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Solution/deployment.yaml
+++ b/src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Solution/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         args:
         - |
           echo "Waiting for database to be ready..."
-          while [ ! -f /shared/database-ready ]; do
+          while [ ! -f /shared/db-ready ]; do
             echo "Still waiting..."
             sleep 5
           done
@@ -39,19 +39,10 @@ spec:
         volumeMounts:
         - name: shared-data
           mountPath: /shared
-      containers:
-      - name: web-app
-        image: nginx:1.21
-        ports:
-        - containerPort: 80
-        volumeMounts:
-        - name: shared-data
-          mountPath: /app/shared
-        - name: app-logs
-          mountPath: /var/log/nginx
       - name: log-shipper
         image: busybox:1.35
         command: ['sh', '-c']
+        restartPolicy: Always
         args:
         - |
           echo "Starting log shipper..."
@@ -68,6 +59,16 @@ spec:
         volumeMounts:
         - name: application-logs
           mountPath: /logs
+      containers:
+      - name: web-app
+        image: nginx:1.21
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: shared-data
+          mountPath: /app/shared
+        - name: application-logs
+          mountPath: /var/log/nginx
       volumes:
       - name: init-scripts
         configMap:
@@ -75,5 +76,5 @@ spec:
           defaultMode: 0755
       - name: shared-data
         emptyDir: {}
-      - name: app-logs
+      - name: application-logs
         emptyDir: {}


### PR DESCRIPTION
This pull request includes several updates to Kubernetes manifests and configurations across multiple exercises. The changes focus on improving clarity, fixing naming inconsistencies, enhancing security practices, and refining functionality. Below is a summary of the most important changes grouped by theme.

### Manifest Clarifications and Naming Fixes:
* Updated the `ServiceAccount` manifest instructions in `README.md` to specify the namespace and name explicitly for better clarity (`src/2.04 - Service Accounts/Exercise/README.md`).
* Renamed the PersistentVolumeClaim from `db-pvc` to `database-pvc` in both the deployment and PVC manifests for consistency (`src/3.07 - Troubleshooting/3.07.3 - Echoes in the Void - The Volume That Never Mounted/Solution/deployment.yaml` and `src/3.07 - Troubleshooting/3.07.3 - Echoes in the Void - The Volume That Never Mounted/Solution/pvc.yaml`). [[1]](diffhunk://#diff-06fc5217763450395e7193d541ce2bac787312784ddcd00ac2b4d3a5d39d3c91L30-R30) [[2]](diffhunk://#diff-3afec453cf1c30907422843343579c5c12945bb619e5b44d90647020f6fa1b61L5-R12)

### Security Enhancements:
* Modified the deployment for accessing secrets via the Kubernetes API instead of mounting them as files, improving security practices (`src/3.07 - Troubleshooting/3.07.4 - Silent Credentials - The Forbidden Secret/Exercise/deployment.yaml` and `src/3.07 - Troubleshooting/3.07.4 - Silent Credentials - The Forbidden Secret/Solution/deployment.yaml`). [[1]](diffhunk://#diff-76a8fd5b2982f29600a9a36a473e8bdebfffce55e893f3415b5fdc085b2b159aL17-L42) [[2]](diffhunk://#diff-dfe67e03b123c062798b474596ba90dca9d531c3cbaa523353a57e421f1cedbaL20-L42)
* Adjusted RBAC rules to allow access to Kubernetes secrets, aligning permissions with the new secret access method (`src/3.07 - Troubleshooting/3.07.4 - Silent Credentials - The Forbidden Secret/Solution/service-account.yaml`).

### Functional Improvements:
* Added a `DROP USER` statement to the database initialization script to ensure clean user creation and updated the database connection hostname in the `configmap.yaml` (`src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Exercise/configmap.yaml` and `src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Solution/configmap.yaml`). [[1]](diffhunk://#diff-ec66a8b298d9c64686ceaff27a5f775cd83bae520a352ffa9230388f0228a50bR9-R16) [[2]](diffhunk://#diff-b0a1d4a4147d63fbb8924b9452ced189560ff393ffec60ff1d38f76dd027af41R9)
* Fixed the readiness check file path in the deployment script and restructured the deployment to include a `web-app` container alongside the log shipper (`src/3.07 - Troubleshooting/3.07.5 - The Phantom Startup - Echoes from the Init Bay/Solution/deployment.yaml`). [[1]](diffhunk://#diff-7062ce3b0f867f7c2bb4efdb28c63c1a2db48da3a7b031022d45ab36e046fd45L34-R45) [[2]](diffhunk://#diff-7062ce3b0f867f7c2bb4efdb28c63c1a2db48da3a7b031022d45ab36e046fd45R62-R79)